### PR TITLE
Pairsum-Fix

### DIFF
--- a/problems/pairsum/parser.py
+++ b/problems/pairsum/parser.py
@@ -39,7 +39,11 @@ class PairsumParser(Parser):
         for i in range(len(raw_instance)):
             raw_instance[i] = int(raw_instance[i])
 
-        return raw_instance[:min(len(raw_instance), instance_size)]
+        parsed_instance = raw_instance[:min(len(raw_instance), instance_size)]
+        if len(parsed_instance) < 4:
+            return []
+
+        return parsed_instance
 
     def parse_solution(self, raw_solution, instance_size):
         removable_entries = []

--- a/tests/test_problem_pairsum.py
+++ b/tests/test_problem_pairsum.py
@@ -24,30 +24,40 @@ class Parsertests(unittest.TestCase):
         # Input of wrong length are discarded
         self.assertEqual(self.parser.split_into_instance_and_solution(['1', '2', '3']), ('', ['']))
 
-    def test_parse_instance(self):
+    def test_parse_instance_ints(self):
         # Entries should be ints
         raw_instance = '1 2 3 4 a'
         self.assertEqual(self.parser.parse_instance(raw_instance, instance_size=10), [1, 2, 3, 4])
 
-        raw_instance = '1 a 3 4 -10'
-        self.assertEqual(self.parser.parse_instance(raw_instance, instance_size=10), [1, 3, 4])
+    def test_parse_instance_too_short(self):
+        # Entries should be ints
+        raw_instance = '1 2 3'
+        self.assertEqual(self.parser.parse_instance(raw_instance, instance_size=10), [])
 
+    def test_parse_instance_negative(self):
+        raw_instance = '1 7 3 4 -10'
+        self.assertEqual(self.parser.parse_instance(raw_instance, instance_size=10), [1, 7, 3, 4])
+
+    def test_parse_instance_huge_entry(self):
         # entries should not exceed 2**63
-        raw_instance = '1 2 3 4 100000000000000000000000000000000000000000000'
+        raw_instance = '1 2 3 4 {}'.format(2**64)
         self.assertEqual(self.parser.parse_instance(raw_instance, instance_size=10), [1, 2, 3, 4])
 
+    def test_parse_instance_prune(self):
         # Instance should be cut down to instance_size number of entries
         raw_instance = '1 2 3 4 5 6'
         self.assertEqual(self.parser.parse_instance(raw_instance, instance_size=5), [1, 2, 3, 4, 5])
 
+    def test_parse_instance_empty(self):
         # empty inputs should be handled
         self.assertEqual(self.parser.parse_instance([], instance_size=3), [])
 
-    def test_parse_solution(self):
+    def test_parse_solution_ints(self):
         # Entries should be ints
         raw_solution = ['0 3 1 2 a']
         self.assertEqual(self.parser.parse_solution(raw_solution, instance_size=10), [0, 3, 1, 2])
 
+    def test_parse_solution_size(self):
         # Entries should not exceed instance_size
         raw_solution = ['0 3 1 2 4']
         self.assertEqual(self.parser.parse_solution(raw_solution, instance_size=3), [0, 3, 1, 2])
@@ -69,21 +79,30 @@ class Verifiertests(unittest.TestCase):
 
     def test_verify_semantics_of_instance(self):
         self.assertTrue(self.verifier.verify_semantics_of_instance([1, 2, 3, 4], instance_size=10))
+
+    def test_verify_semantics_of_instance_empty(self):
         self.assertFalse(self.verifier.verify_semantics_of_instance([], instance_size=10))
 
-    def test_verify_semantics_of_solution(self):
+    def test_verify_semantics_of_solution_empty(self):
         self.assertFalse(self.verifier.verify_semantics_of_solution([], 10, solution_type=False))
+
+    def test_verify_semantics_of_solution_too_short(self):
         self.assertFalse(self.verifier.verify_semantics_of_solution([0, 3, 1], 10, solution_type=False))
+
+    def test_verify_semantics_of_solution_duplicates(self):
         self.assertFalse(self.verifier.verify_semantics_of_solution([0, 3, 1, 1], 10, solution_type=False))
+
+    def test_verify_semantics_of_solution_normal(self):
         self.assertTrue(self.verifier.verify_semantics_of_solution([0, 3, 1, 2], 10, solution_type=False))
 
-    def test_verify_solution_against_instance(self):
+    def test_verify_solution_against_instance_normal(self):
         # Valid solutions should be accepted
         instance = [1, 2, 3, 4]
         solution = [0, 3, 1, 2]
         self.assertTrue(self.verifier.verify_solution_against_instance(instance,
                                                                        solution, instance_size=10, solution_type=False))
 
+    def test_verify_solution_against_instance_wrong(self):
         # Invalid solutions should not be accepted
         instance = [1, 2, 3, 4]
         solution = [0, 1, 2, 3]


### PR DESCRIPTION
The Pairsum problem caused a crash when a pruned and parsed instance had less than 4 entries. As an instance with fewer than 4 entries is invalid, this is now appropriately handled.

Tests for this case were added.